### PR TITLE
add an optional argument to the build script to specify output path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,13 @@
 
 THEME_PATH="_vendor/github.com/mitodl/ocw-course-hugo-theme"
 PDFJS_PATH="pdfjs"
+# check for optional output path argument, default to dist
+if [ $# -eq 0 ]
+  then
+    OUTPUT_PATH="dist"
+else
+  OUTPUT_PATH="$1"
+fi
 
 # init or update the pdfjs submodule and install our local dependencies
 git submodule update --init --recursive
@@ -22,6 +29,6 @@ yarn install --cwd $THEME_PATH
 npm run build:webpack --prefix $THEME_PATH
 
 # copy artifacts where they belong
-mkdir -p static/pdfjs
-cp -r pdfjs/build/generic/* static/pdfjs
-cp -r $THEME_PATH/dist/* $THEME_PATH/static
+mkdir -p $OUTPUT_PATH/pdfjs
+cp -r pdfjs/build/generic/* $OUTPUT_PATH/pdfjs
+cp -r $THEME_PATH/dist/* $OUTPUT_PATH


### PR DESCRIPTION
#### What are the relevant tickets?

Closes https://github.com/mitodl/ocw-course-hugo-starter/issues/4

#### What's this PR do?

This PR adds an optional argument to `build.sh` to specify an output directory for the build artifacts.

#### How should this be manually tested?

Run the build script with a test output location and ensure that the artifacts appear in the target location.  For example:

```
./build.sh ~/Documents/build_test
```

