### PR TITLE
Fixed gitignore so specific Hugo site content/data/assets are ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,11 +45,6 @@ yarn-debug.log*
 yarn-error.log*
 .yarn-integrity
 data/webpack.json
-static/pdfjs
-static/zips
-static/webpack
-content/courses/*
-!content/courses/_index.md
 ocw-to-hugo.*.log
 *.tgz
 zips
@@ -76,3 +71,10 @@ venv/
 
 # webpack bundle analysis
 stats.json
+
+# Specific Hugo site content/data/assets
+content/*
+!content/.keep
+data/*
+!data/.keep
+static/


### PR DESCRIPTION
To test:
- Add any files/dirs in the `content` or `data` directories. Nothing should be added to version control
- Add a /static directory with any contents. Nothing should be added to version control