### PR TITLE
update build script to match new `ocw-to-hugo` output structure and add verbose switch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,12 +40,12 @@ _mainScript_() {
     for COURSE in $EXTERNAL_COURSES_PATH/*; do
       if [[ -d $COURSE ]]; then
         COURSE_ID=${COURSE#"$EXTERNAL_COURSES_PATH/"}
-        eval "cp $COURSE/data/course.json data/course.json"
+        cp $COURSE/data/course.json data/course.json
         HUGO_COMMAND="hugo --contentDir $COURSE/content -d $OUTPUT_PATH/courses/$COURSE_ID/"
         if [[ -n $BASE_URL ]]; then
           HUGO_COMMAND="$HUGO_COMMAND --baseUrl $BASE_URL/$COURSE_ID/"
         fi
-        if [ $VERBOSE ne true ]; then
+        if [[ $VERBOSE -ne true ]]; then
           HUGO_COMMAND="$HUGO_COMMAND --quiet"
         else
           echo "Rendering Hugo site for $COURSE_ID..."

--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,7 @@ _mainScript_() {
     for COURSE in $EXTERNAL_COURSES_PATH/*; do
       if [[ -d $COURSE ]]; then
         COURSE_ID=${COURSE#"$EXTERNAL_COURSES_PATH/"}
+        eval "cp $COURSE/data/course.json data/course.json"
         HUGO_COMMAND="hugo --contentDir $COURSE/content -d $OUTPUT_PATH/courses/$COURSE_ID/"
         if [[ -n $BASE_URL ]]; then
           HUGO_COMMAND="$HUGO_COMMAND --baseUrl $BASE_URL/$COURSE_ID/"


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/issues/214
Closes https://github.com/mitodl/ocw-course-hugo-starter/issues/8

#### What's this PR do?
This PR updates the build script to match the new `ocw-to-hugo` output structure that's changed by [this](https://github.com/mitodl/ocw-to-hugo/pull/216) PR.  It also makes the output quiet by default and adds a verbose switch to turn it back on for testing / debugging.

#### How should this be manually tested?
 - Follow the instructions in [this](https://github.com/mitodl/ocw-to-hugo/pull/216) PR to generate markdown
 - Spin up `ocw-www` locally
 - Run `./build.sh -o ~/Code/ocw-www/site/public -c ~/Code/ocw-to-hugo/private/output -b http://localhost:3000/courses`
 - Browse to a test course locally running under `ocw-www` and ensure it renders correctly, for example: http://localhost:3000/courses/6-034-artificial-intelligence-fall-2010/
 - Run `./build.sh -o ~/Code/ocw-www/site/public -c ~/Code/ocw-to-hugo/private/output -b http://localhost:3000/courses -v` and ensure the same process works, but you should see verbose output when rendering the hugo sites