### PR TITLE
specify config file and directory in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ _mainScript_() {
       if [[ -d $COURSE ]]; then
         COURSE_ID=${COURSE#"$EXTERNAL_COURSES_PATH/"}
         cp $COURSE/data/course.json data/course.json
-        HUGO_COMMAND="hugo --contentDir $COURSE/content -d $OUTPUT_PATH/courses/$COURSE_ID/"
+        HUGO_COMMAND="hugo --config config.toml --configDir $COURSE/config --contentDir $COURSE/content -d $OUTPUT_PATH/courses/$COURSE_ID/"
         if [[ -n $BASE_URL ]]; then
           HUGO_COMMAND="$HUGO_COMMAND --baseUrl $BASE_URL/$COURSE_ID/"
         fi


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/issues/229

#### What's this PR do?
Moving forward, we are going to want to decentralize our Hugo configuration and allow for parts to be introduced piecemeal. 
 This PR changes the `hugo` bulid command in the build script to use the config included in the starter as well as any config included in the `ocw-to-hugo` output itself.

#### How should this be manually tested?
 - Sync the `open-learning-course-data-production` s3 bucket to your machine
 - Clone `ocw-to-hugo` and check out the `cg/external-links` branch
 - Convert all courses to markdown in `ocw-to-hugo` by running `node . -i ~/Code/open-learning-course-data-producution -o private/output --rm`, swapping out my path to `open-learning-course-data-production` with your own
 - Clone `ocw-www` and read the readme to get the site spun up.
 - Back in this repo, run `./build.sh -o ~/Code/ocw-www/site/public -c ~/Code/ocw-to-hugo/private/output -b http://localhost:3000/courses -v` again replacing my path to the repos used here with your own
 - Ensure that the build completes without error
 - Navigate to http://localhost:3000/courses/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020 and verify that there is a link in the left nav titled "ONLINE PUBLICATION" that links to https://biology.mit.edu/undergraduate/current-students/subject-offerings/covid-19-sars-cov-2-and-the-pandemic/
 - Navigate to any other course site and verify that the nav and pages are generated properly, click links and browse around a bit

#### Any background context you want to provide?
This PR was made to support changes made by https://github.com/mitodl/ocw-to-hugo/pull/239

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/112539841-dc3cb700-8d87-11eb-8805-0ed1413fcb65.png)
![image](https://user-images.githubusercontent.com/12089658/112539884-e8287900-8d87-11eb-95e7-ad2e55602c15.png)
